### PR TITLE
Get kms key from env

### DIFF
--- a/kms_ext/extension.py
+++ b/kms_ext/extension.py
@@ -18,7 +18,6 @@ from meltano.edk.extension import ExtensionBase
 from .secrets import EnvVar, Secret, SecretsFile
 
 log = structlog.get_logger()
-kms_key_id = os.environ.get("KMS_KEY_ID")
 
 class KMSCrypto:
     """Encrypt plaintext using KMS-compliant RSA algorithm."""
@@ -106,6 +105,11 @@ class KMS(ExtensionBase):
         output_path: Path = Path(".env"),
     ) -> Path:
         client = boto3.client("kms")
+
+        try:
+            kms_key_id = os.environ["KMS_KEY_ID"]
+        except KeyError as ex:
+            raise Exception("The environment variable $KMS_KEY_ID must be set to decrypt") from ex
 
         with open(input_path) as ciphertext_file:
             secrets = SecretsFile.parse_raw(ciphertext_file.read())

--- a/kms_ext/extension.py
+++ b/kms_ext/extension.py
@@ -7,8 +7,8 @@ from typing import Any
 
 import boto3
 import dotenv
-import structlog
 import os
+import structlog
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from dotenv import dotenv_values

--- a/kms_ext/main.py
+++ b/kms_ext/main.py
@@ -42,14 +42,12 @@ def describe(
 
 @app.command()
 def encrypt(
-    kms_key_id: str,
     public_key_path: Path,
     dotenv_path: Optional[Path] = typer.Option(Path(".env")),
     output_path: Optional[Path] = typer.Option(Path("secrets.yml")),
 ) -> None:
     """Encrypt a given dotenv file with a given RSA Public Key (PEM file)."""
     ext.encrypt(
-        kms_key_id=kms_key_id,
         public_key_path=public_key_path,
         dotenv_path=dotenv_path,
         output_path=output_path,

--- a/kms_ext/secrets.py
+++ b/kms_ext/secrets.py
@@ -15,5 +15,4 @@ class EnvVar(BaseModel):
 
 
 class SecretsFile(YamlModel):
-    kms_key_id: str = None
     env: List[EnvVar]

--- a/kms_ext/secrets.py
+++ b/kms_ext/secrets.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import List
 
 from pydantic import BaseModel
@@ -17,5 +15,5 @@ class EnvVar(BaseModel):
 
 
 class SecretsFile(YamlModel):
-    kms_key_id: str | None = None
+    kms_key_id: str = None
     env: List[EnvVar]

--- a/kms_ext/secrets.py
+++ b/kms_ext/secrets.py
@@ -15,5 +15,4 @@ class EnvVar(BaseModel):
 
 
 class SecretsFile(YamlModel):
-    kms_key_id: str
     env: List[EnvVar]

--- a/kms_ext/secrets.py
+++ b/kms_ext/secrets.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import List
 
 from pydantic import BaseModel
@@ -15,4 +17,5 @@ class EnvVar(BaseModel):
 
 
 class SecretsFile(YamlModel):
+    kms_key_id: str | None = None
     env: List[EnvVar]


### PR DESCRIPTION
The KMS key ID is now passed to the container via an env var `KMS_KEY_ID` automatically so we don't need to provide `kms_key_id` when encrypting anymore. 

Decrypting should retrieve this value from the environment. 

Closes: https://github.com/meltano/kms-ext/issues/3